### PR TITLE
Add CMake build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Build directories
+build/
+build-*/
+out/
+
+# CMake generated files
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+compile_commands.json
+CTestTestfile.cmake
+Testing/
+
+# Compiled binaries and objects
+*.exe
+*.dll
+*.lib
+*.obj
+*.o
+*.a
+
+# IDE and editor files
+.vs/
+.vscode/
+.idea/
+*.suo
+*.user
+*.VC.db
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(hello_world VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(hello main.cpp)
+
+if(MSVC)
+  target_compile_options(hello PRIVATE /W4)
+else()
+  target_compile_options(hello PRIVATE -Wall -Wextra -Wpedantic)
+endif()

--- a/README.md
+++ b/README.md
@@ -4,9 +4,24 @@ test
 
 ## C++ Hello World
 
-这个仓库现在包含一个最基础的 C++ Hello World 示例程序。
+这个仓库现在包含一个最基础的 C++ Hello World 示例程序，并新增了 `CMakeLists.txt`，可在 Linux/macOS/Windows 等多环境中统一构建。
 
-### 运行方式
+### 使用 CMake 构建（推荐）
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+运行程序：
+
+```bash
+./build/hello
+```
+
+> Windows + Visual Studio 生成器下，默认可执行文件通常位于 `build/Debug/hello.exe`。
+
+### 手动编译（可选）
 
 ```bash
 g++ -std=c++17 main.cpp -o hello


### PR DESCRIPTION
## Summary
- Add a portable CMake build configuration for the C++ Hello World example
- Document CMake build and run commands in the README
- Add a .gitignore for CMake build output, compiled binaries, and common IDE files

## Testing
- `cmake -S . -B build-msvc -G "NMake Makefiles"`
- `cmake --build build-msvc`
- `build-msvc\hello.exe`