### PR TITLE
Add popup greeting and build script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,48 @@
+param(
+    [ValidateSet("Debug", "Release", "RelWithDebInfo", "MinSizeRel")]
+    [string]$Config = "Debug",
+    [string]$BuildDir = "build"
+)
+
+$ErrorActionPreference = "Stop"
+
+$RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$BuildPath = Join-Path $RootDir $BuildDir
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Command,
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code ${LASTEXITCODE}: $Command $($Arguments -join ' ')"
+    }
+}
+
+Write-Host "Configuring project..."
+Invoke-Step cmake -S $RootDir -B $BuildPath
+
+Write-Host "Building project ($Config)..."
+Invoke-Step cmake --build $BuildPath --config $Config
+
+$ExeName = "hello"
+if ($IsWindows -or $env:OS -eq "Windows_NT") {
+    $ExeName = "hello.exe"
+}
+
+$CandidatePaths = @(
+    (Join-Path (Join-Path $BuildPath $Config) $ExeName),
+    (Join-Path $BuildPath $ExeName)
+)
+
+$ExePath = $CandidatePaths | Where-Object { Test-Path $_ } | Select-Object -First 1
+
+if ($ExePath) {
+    Write-Host "Build finished: $ExePath"
+} else {
+    Write-Host "Build finished. Executable was not found in the common output paths."
+}

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,14 @@
 #include <iostream>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 int main() {
-    std::cout << "Hello, World!" << std::endl;
+#ifdef _WIN32
+    MessageBoxA(nullptr, "hello world", "Greeting", MB_OK | MB_ICONINFORMATION);
+#else
+    std::cout << "hello world" << std::endl;
+#endif
     return 0;
 }


### PR DESCRIPTION
## Summary
- Show `hello world` in a Windows runtime message box, with console output preserved for non-Windows builds
- Add `build.ps1` to configure and build the CMake project from PowerShell

## Testing
- `./build.ps1` was executed; it now stops correctly on CMake failures
- Full build could not complete in the current environment because no C++ compiler was found in PATH