### PR TITLE
Add GitHub Actions CI and Release workflows; add CMake install target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build
+        run: cmake --build build --config Debug
+
+      - name: Run executable on console platforms
+        if: runner.os != 'Windows'
+        run: ./build/hello

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-release-artifacts:
+    name: Build release artifact (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Install
+        run: cmake --install build --config Release --prefix dist
+
+      - name: Package archive (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: tar -czf hello-world-${{ runner.os }}-${{ runner.arch }}.tar.gz -C dist .
+
+      - name: Package archive (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -Path dist\* -DestinationPath hello-world-${{ runner.os }}-${{ runner.arch }}.zip
+
+      - name: Upload workflow artifact (Linux/macOS)
+        if: runner.os != 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: hello-world-${{ runner.os }}-${{ runner.arch }}
+          path: hello-world-${{ runner.os }}-${{ runner.arch }}.tar.gz
+          if-no-files-found: error
+
+      - name: Upload workflow artifact (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: hello-world-${{ runner.os }}-${{ runner.arch }}
+          path: hello-world-${{ runner.os }}-${{ runner.arch }}.zip
+          if-no-files-found: error
+
+  publish-github-release:
+    name: Publish GitHub Release
+    needs: build-release-artifacts
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+          merge-multiple: true
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-artifacts/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,3 +13,5 @@ if(MSVC)
 else()
   target_compile_options(hello PRIVATE -Wall -Wextra -Wpedantic)
 endif()
+
+install(TARGETS hello RUNTIME DESTINATION bin)


### PR DESCRIPTION
### Motivation

- Enable continuous integration across Linux, macOS, and Windows and to run the built executable during PRs and pushes.
- Produce cross-platform release artifacts and automate publishing of tagged releases.

### Description

- Add `.github/workflows/ci.yml` to configure a matrix CI that runs `cmake` configure and build in Debug on `ubuntu-latest`, `macos-latest`, and `windows-latest`, and runs the executable `./build/hello` on non-Windows runners.
- Add `.github/workflows/release.yml` to build Release artifacts across the same OS matrix, install into a `dist` prefix, package artifacts as `tar.gz` on Linux/macOS and `zip` on Windows, upload them as workflow artifacts, and publish a GitHub Release for tag pushes.
- Update `CMakeLists.txt` to add an `install(TARGETS hello RUNTIME DESTINATION bin)` line so the release job can install and package the built binary.

### Testing

- No automated tests were executed as part of this PR; CI and Release workflows were added and will run on future pushes, PRs, and tags when triggered.
- The configured CI job will run `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`, `cmake --build build --config Debug`, and `./build/hello` on non-Windows runners when the workflow is executed.
- The release job will run `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, `cmake --build build --config Release`, `cmake --install build --config Release --prefix dist`, package artifacts, and upload them as workflow artifacts when a matching tag is pushed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21acda5c68832494f0b4dcf926d9ac)